### PR TITLE
Use case-insensitive matching for Git error "Not a valid object name"

### DIFF
--- a/Assets/DevLocker/VersionControl/WiseGit/Editor/WiseGitIntegration.cs
+++ b/Assets/DevLocker/VersionControl/WiseGit/Editor/WiseGitIntegration.cs
@@ -1572,7 +1572,7 @@ namespace DevLocker.VersionControl.WiseGit
 
 				// Remote directory not found.
 				// fatal: Not a valid object name origin/master:sadasda
-				if (result.Error.Contains("Not a valid object name"))
+				if (result.Error.Contains("Not a valid object name", StringComparison.OrdinalIgnoreCase))
 					return ListOperationResult.NotFound;
 
 				return (ListOperationResult) ParseCommonStatusError(result.Error);


### PR DESCRIPTION
Fixes #2

Git is lowercasing the `fatal: Not a valid object name` error message
to follow its CodingGuidelines. This change makes the string matching
case-insensitive so it works with both the current and future Git versions.

Changes:
- Use `StringComparison.OrdinalIgnoreCase` for the error message check

See: https://lore.kernel.org/git/pull.2052.git.1771836302101.gitgitgadget@gmail.com